### PR TITLE
Fix speedup after losing activity focus

### DIFF
--- a/RetroBreaker/app/src/main/java/br/usp/ime/retrobreaker/GameActivity.java
+++ b/RetroBreaker/app/src/main/java/br/usp/ime/retrobreaker/GameActivity.java
@@ -131,7 +131,9 @@ public class GameActivity extends Activity {
 	    				| View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
 	    				| View.SYSTEM_UI_FLAG_FULLSCREEN
 	    				| View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-	    	}
+	    	} else {
+				State.setGamePaused(true);
+			}
 	    }
 	}
 	

--- a/RetroBreaker/app/src/main/java/br/usp/ime/retrobreaker/game/TouchSurfaceView.java
+++ b/RetroBreaker/app/src/main/java/br/usp/ime/retrobreaker/game/TouchSurfaceView.java
@@ -44,7 +44,7 @@ public class TouchSurfaceView extends GLSurfaceView {
 		public void onDrawFrame(GL10 gl) {
 			mCurrentTime = System.nanoTime();
 			mElapsedTime = (mCurrentTime - mPrevFrameTime)/Constants.NANOS_PER_SECONDS;
-			mLag += mElapsedTime;
+            if (!State.getGamePaused()) mLag += mElapsedTime;
 			/* You can set Config.FPS_LIMIT parameter on Constants.java file to limit
 			 * frame rendering for debugging purposes (but with game loop this shouldn't
 			 * be a problem anymore. */
@@ -66,7 +66,7 @@ public class TouchSurfaceView extends GLSurfaceView {
 					mGame.updateState();
 				}
 				mLag -= Config.MS_PER_UPDATE;
-				
+
 				/* If the device is so slow that it can't maintain a nice frame rate, skip
 				 * game processing so the game runs slower on that device. */
 				if (frame_counter >= Config.FRAME_SKIP) {


### PR DESCRIPTION
Fix for issue #6 

When the game loses focus (user presses home or switch app button for example), mLag seems to carry on increasing in the background. Resuming the game then causes it to update too frequently, speeding the game up, because of false lag.

The `State.setGamePaused(true);` addition in GameActivity pauses the game if you pull the notification drawer down.